### PR TITLE
WI#23712 - Ability to Insert Action with Callflow

### DIFF
--- a/app.js
+++ b/app.js
@@ -894,6 +894,7 @@ define(function(require) {
 					}
 				}, !self.appFlags.showAllCallflows && {
 					filters: {
+						paginate: false,
 						filter_not_numbers: 'no_match',
 						'filter_not_ui_metadata.origin': [
 							'voip',
@@ -903,7 +904,7 @@ define(function(require) {
 						]
 					}
 				}, searchValue && {
-					value: searchValue
+					value: searchValue 
 				});
 
 			self.callApi({
@@ -1038,7 +1039,7 @@ define(function(require) {
 			$('.buttons').empty();
 
 			$('.save', buttons).click(function() {
-				console.log('Save Callflow');
+
 				if (self.flow.numbers && self.flow.numbers.length > 0) {
 					self.save();
 				} else {
@@ -1047,7 +1048,7 @@ define(function(require) {
 			});
 
 			$('.delete', buttons).click(function() {
-				console.log('Delete Callflow');
+
 				if (self.flow.id) {
 					monster.ui.confirm(self.i18n.active().oldCallflows.are_you_sure, function() {
 						self.callApi({
@@ -1076,16 +1077,14 @@ define(function(require) {
 
 			// copy callflow
 			$('.duplicate', buttons).click(function() {
-				console.log('Copy Callflow');
                 delete(self.dataCallflow.id);
                 self.flow.numbers = [];
 				self.flow.name = self.flow.name + ' (Copy)';
                 self.flow.id = undefined;
                 self.repaintFlow();
 				monster.ui.alert(self.i18n.active().oldCallflows.duplicate_callflow_info);
-				/* $('.delete', '#ws_callflow').hide(); */
 				$('#pending_change', '#ws_callflow').show();
-				$('.duplicate', '#ws_callflow').hide(); // copy callflow
+				$('.duplicate', '#ws_callflow').addClass('disabled'); // copy callflow
 				$('.save', '#ws_callflow').addClass('pulse-box');
                 
             });
@@ -1153,7 +1152,7 @@ define(function(require) {
 			self.flow.root.key = 'flow';
 			self.flow.numbers = [];
 			self.flow.caption_map = {};
-			self.formatFlow();
+			self.formatFlow();	
 		},
 
 		formatFlow: function() {
@@ -1226,23 +1225,28 @@ define(function(require) {
 					});
 				};
 
-				this.addChild = function(branch) {
+				this.addChild = function(branch, position) {
 					if (!(branch.actionName in this.potentialChildren())) {
 						return false;
 					}
-
+				
 					if (branch.contains(this)) {
 						return false;
 					}
-
+				
 					if (branch.parent) {
 						branch.parent.removeChild(branch);
 					}
-
+				
 					branch.parent = this;
-
-					this.children.push(branch);
-
+				
+					// Insert the new branch at the specified position or at the end if position is not provided
+					if (typeof position === 'number' && position >= 0 && position < this.children.length) {
+						this.children.splice(position, 0, branch);
+					} else {
+						this.children.push(branch);
+					}
+				
 					return true;
 				};
 
@@ -1349,11 +1353,11 @@ define(function(require) {
 			var self = this;
 			if (pending_change) {
 				$('#pending_change', '#ws_callflow').show();
-				$('.duplicate', '#ws_callflow').hide(); // copy callflow
+				$('.duplicate', '#ws_callflow').addClass('disabled'); // copy callflow
 				$('.save', '#ws_callflow').addClass('pulse-box');
 			} else {
 				$('#pending_change', '#ws_callflow').hide();
-				$('.duplicate', '#ws_callflow').show(); // copy callflow
+				$('.duplicate', '#ws_callflow').removeClass('disabled'); // copy callflow
 				$('.save', '#ws_callflow').removeClass('pulse-box');
 			}
 		},
@@ -1741,7 +1745,7 @@ define(function(require) {
 					}));
 				}
 
-				//make names of callflow nodes clickable
+				// make names of callflow nodes clickable
 				$('.details a', node_html).click(function(event) {
 					event.stopPropagation();
 					var previewCallflowId = self.flow.nodes[$(node_html).find('.delete').attr('id')].data.data.id,
@@ -1770,54 +1774,178 @@ define(function(require) {
 
 				$(this).droppable({
 					drop: function(event, ui) {
-						var target = self.flow.nodes[$(this).attr('id')],
+						var targetId = $(this).attr('id'),
+							target = self.flow.nodes[targetId],
 							action,
-							branch;
-
-						if (ui.draggable.hasClass('action')) {
-							action = ui.draggable.attr('name');
-
-							branch = self.branch(action);
-							branch.caption = self.actions[action].caption(branch, self.flow.caption_map);
-
-							if (target.addChild(branch)) {
-								if (branch.parent && ('key_caption' in self.actions[branch.parent.actionName])) {
-									branch.key_caption = self.actions[branch.parent.actionName].key_caption(branch, self.flow.caption_map);
-
-									self.actions[branch.parent.actionName].key_edit(branch, function() {
-										self.actions[action].edit(branch, function() {
-											self.repaintFlow();
-										});
-									});
-								} else {
-									self.actions[action].edit(branch, function() {
-										self.repaintFlow();
-									});
-								}
-
-								//This is just in case something goes wrong with the dialog
-								self.repaintFlow();
+							branch,
+							validActionNames = [
+								'menu[id=*]', 
+								'branch_variable[]', 
+								'temporal_route[]'
+							];
+						
+						/* // commented out as don't believe latter section not required
+						function addChildBelow(parent, node, position) {
+							if (parent) {
+								// add the node below the target at the specified position
+								parent.addChild(node, position);
+							} else {
+								// if the target has no parent, add the node as a sibling
+								self.flow.nodes[node.id] = node;
+								self.flow.root = node;
 							}
 						}
+						*/
+						
+						function addChildBelow(parent, node, position) {
+							// add the node below the target at the specified position
+							parent.addChild(node, position);
+							
+						}
+						
+						// action is a new item being added to the callflow
+						if (ui.draggable.hasClass('action')) {
+							action = ui.draggable.attr('name');
+							branch = self.branch(action);
+							branch.caption = self.actions[action].caption(branch, self.flow.caption_map);
+				
+							// handle callflow actions that support parallel children
+							if (validActionNames.includes(target.actionName)) {
+							
+								addChildBelow(target, branch);
 
-						if (ui.draggable.hasClass('node')) {
-							var branch = self.flow.nodes[ui.draggable.attr('id')];
+							} else {
 
-							if (target.addChild(branch)) {
-								// If we move a node, destroy its key
-								branch.key = '_';
+								// check if callflow actions that support parallel children
+								if (validActionNames.includes(action)) {
+									
+									// store the children of the target temporarily
+									var originalChildren = target.children.slice();
 
-								if (branch.parent && ('key_caption' in self.actions[branch.parent.actionName])) {
-									branch.key_caption = self.actions[branch.parent.actionName].key_caption(branch, self.flow.caption_map);
+									// handle new callflow with no children
+									if (originalChildren.length == 0) {
+							
+										addChildBelow(target, branch);
+
+									}
+
+									else {
+
+										var parentKey = '_';
+										var parentKeyCaption = 'Default action'
+
+										// update child branch key value
+										originalChildren[0].key = parentKey;
+										originalChildren[0].key_caption = parentKeyCaption;
+						
+										// remove the children from the target
+										target.children = [];
+						
+										// add the new branch below the target
+										addChildBelow(target, branch, originalChildren.length + 1);
+						
+										// re-add the original children as children of the new branch
+										originalChildren.forEach(function(child) {
+											branch.addChild(child);
+										});
+
+									}
+									
 								}
 
-								ui.draggable.remove();
-								self.repaintFlow();
+								else {
+
+									// store the children of the target temporarily
+									var originalChildren = target.children.slice();
+					
+									// remove the children from the target
+									target.children = [];
+					
+									// add the new branch below the target
+									addChildBelow(target, branch, originalChildren.length + 1);
+					
+									// re-add the original children as children of the new branch
+									originalChildren.forEach(function(child) {
+										branch.addChild(child);
+									});
+
+								}
+								
 							}
+				
+							if (branch.parent && ('key_caption' in self.actions[branch.parent.actionName])) {
+								branch.key_caption = self.actions[branch.parent.actionName].key_caption(branch, self.flow.caption_map);
+				
+								self.actions[branch.parent.actionName].key_edit(branch, function() {
+									self.actions[action].edit(branch, function() {
+										// repaint the flow after all operations are completed
+										self.repaintFlow();
+									});
+								});
+							} else {
+								self.actions[action].edit(branch, function() {
+									// repaint the flow after all operations are completed
+									self.repaintFlow();
+								});
+							}
+						}
+				
+						// node is an action already on the callflow
+						if (ui.draggable.hasClass('node')) {
+							
+							// handle callflow actions that support parallel children
+							if (validActionNames.includes(target.actionName)) {
+							
+								var branch = self.flow.nodes[ui.draggable.attr('id')];
+
+								if (target.addChild(branch)) {
+
+									// if we move a node, destroy its key
+									
+									branch.key = '_';
+	
+									if (branch.parent && ('key_caption' in self.actions[branch.parent.actionName])) {
+
+										branch.key_caption = self.actions[branch.parent.actionName].key_caption(branch, self.flow.caption_map);
+									
+									}
+									
+									ui.draggable.remove();
+									self.repaintFlow();
+
+								}					
+
+							} else {
+
+								var draggedNodeId = ui.draggable.attr('id');
+								var draggedNode = self.flow.nodes[draggedNodeId];
+					
+								// Store the children of the target temporarily
+								var originalChildren = target.children.slice();
+					
+								// Remove the children from the target
+								target.children = [];
+					
+								// Add the dragged node below the target
+								addChildBelow(target, draggedNode);
+					
+								// Re-add the original children as children of the dragged node
+								originalChildren.forEach(function(child) {
+									draggedNode.addChild(child);
+								});
+					
+								if (draggedNode.parent && ('key_caption' in self.actions[draggedNode.parent.actionName])) {
+									draggedNode.key_caption = self.actions[draggedNode.parent.actionName].key_caption(draggedNode, self.flow.caption_map);
+								}
+					
+								// Repaint the flow after all operations are completed
+								self.repaintFlow();
+
+							}	
 						}
 					}
 				});
-
+				
 				// dragging the whole branch
 				if ($(this).attr('name') !== 'root') {
 					$(this).draggable({
@@ -1844,19 +1972,76 @@ define(function(require) {
 						}
 					});
 				}
-			});
+			});		
 
+			// delete a callflow action
 			$('.node-options .delete', layout).click(function() {
-				var node = self.flow.nodes[$(this).attr('id')];
 
-				if (node.parent) {
-					node.parent.removeChild(node);
+				var validActionNames = [
+					'menu[id=*]', 
+					'branch_variable[]', 
+					'temporal_route[]'
+				];
+				var nodeId = $(this).attr('id');
+				var node = self.flow.nodes[nodeId];
 
-					self.repaintFlow();
+				// handle callflow actions that support parallel children
+				if (validActionNames.includes(node.actionName)) {
+
+					monster.ui.confirm(self.i18n.active().oldCallflows.delete_callflow_action_confirm + '<br>' + self.i18n.active().oldCallflows.delete_callflow_action_note_1, function() { 
+
+						if (node.parent) {
+							node.parent.removeChild(node);
+
+							self.repaintFlow();
+
+						}
+					
+					});
+
 				}
-			});
+
+				else {
+
+					if (node.parent) {
+
+						monster.ui.confirm(self.i18n.active().oldCallflows.delete_callflow_action_confirm + '<br>' + self.i18n.active().oldCallflows.delete_callflow_action_note_2, function() {
+							var parentNode = node.parent;
+							var parentKey = node.key;
+							var parentKeyCaption = node.key_caption;
+												
+							// store the index of the node in its parent's children array
+							var nodeIndex = parentNode.children.indexOf(node);
+					
+							// remove the node from its parent
+							parentNode.removeChild(node);
+					
+							// move the children of the deleted node to the position of the deleted node
+							for (var i = node.children.length - 1; i >= 0; i--) {
+								var childNode = node.children[i];
+								parentNode.children.splice(nodeIndex, 0, node.children[i]);
+
+								// set the parent properties of the child node
+								childNode.parent = parentNode;
+								childNode.key = parentKey;
+								childNode.key_caption = parentKeyCaption;
+
+							}
+					
+							// repaint the flow after all operations are completed
+							self.repaintFlow();
+
+						});
+
+					}
+
+				}
+
+
+			});		
 
 			return layout;
+
 		},
 
 		renderBranch: function(branch) {
@@ -1939,7 +2124,7 @@ define(function(require) {
 				data: dataTemplate
 			}));
 
-			// Set the basic drawer to open
+			// set the basic drawer to open
 			$('#Basic', tools).removeClass('inactive').addClass('active');
 
 			$('.category .open', tools).click(function() {
@@ -2032,30 +2217,76 @@ define(function(require) {
 		},
 
 		enableDestinations: function(el) {
-			var self = this;
+			
+			var terminatingActionNames = [
+				'group_pickup[]',
+				'receive_fax[]',
+				'pivot[]',
+				'disa[]',
+				'response[]',
+				'offnet[]',
+				'resources[]'
+			],
+				self = this;
 
 			$('.node').each(function() {
-				var activate = true,
-					target = self.flow.nodes[$(this).attr('id')];
 
-				if (el.attr('name') in target.potentialChildren()) {
-					if (el.hasClass('node') && self.flow.nodes[el.attr('id')].contains(target)) {
+				var actionName = el.attr('name')
+				
+				// prevent inserting callflow action where selected action is a terminating action
+				if (terminatingActionNames.includes(actionName)) {
+
+					var activate = true,
+						target = self.flow.nodes[$(this).attr('id')];
+
+					if (el.attr('name') in target.potentialChildren()) {
+						if (el.hasClass('node') && self.flow.nodes[el.attr('id')].contains(target)) {
+							activate = false;
+						}
+					} else {
 						activate = false;
 					}
-				} else {
-					activate = false;
+
+					if (activate) {
+						$(this).addClass('active');
+					} else {
+						$(this).addClass('inactive');
+						$(this).droppable('disable');
+					}
+				
 				}
 
-				if (activate) {
-					$(this).addClass('active');
-				} else {
-					$(this).addClass('inactive');
-					$(this).droppable('disable');
+				else {
+
+					var activate = true,
+						target = self.flow.nodes[$(this).attr('id')];
+
+					// prevent adding callflow action after a terminating action
+					if (terminatingActionNames.includes(target.actionName)) {
+						if (el.attr('name') in target.potentialChildren()) {
+							if (el.hasClass('node') && self.flow.nodes[el.attr('id')].contains(target)) {
+								activate = false;
+							}
+						} else {
+							activate = false;
+						}
+
+						if (activate) {
+							$(this).addClass('active');
+						} else {
+							$(this).addClass('inactive');
+							$(this).droppable('disable');
+						}
+					}
+
 				}
+			
 			});
+			
 		},
 
 		disableDestinations: function() {
+			
 			$('.node').each(function() {
 				$(this).removeClass('active');
 				$(this).removeClass('inactive');
@@ -2063,8 +2294,9 @@ define(function(require) {
 			});
 
 			$('.tool').removeClass('active');
-		},
 
+		},
+		
 		save: function() {
 			var self = this;
 

--- a/i18n/en-US.json
+++ b/i18n/en-US.json
@@ -1246,8 +1246,6 @@
 		"advanced_cat": "Advanced",
 		"call_recording_cat": "Call Recording",
 		"caller_id_cat": "Caller-ID",
-		"duplicate_callflow": "Copy callflow",
-		"duplicate_callflow_info": "The Callflow has been copied but not saved. Please assign a new number to the Callflow and update the name before saving.",
 		"delete_callflow": "Delete callflow",
 		"save_changes": "Save changes",
 		"invalid_number": "Invalid number!",
@@ -1397,7 +1395,13 @@
 				"current": "Current",
 				"original": "Original"
 			}
-		}
+		},
+		"duplicate_callflow": "Copy callflow",
+		"duplicate_callflow_info": "The Callflow has been copied but not saved. Please assign a new number to the Callflow and update the name before saving.",
+		"delete_callflow_action_confirm": "Are you sure you want to delete this callflow action?",
+		"delete_callflow_action_note_1": "This callflow action supports multiple child branches,<br> therefor all child items will be deleted.",
+		"delete_callflow_action_note_2": "Any child items will be moved up into the place of the deleted callflow action."
+
 	},
 	"__comment": "UI-1260: created common control for carrier selection",
 	"__version": "v3.20_s2",

--- a/style/app.css
+++ b/style/app.css
@@ -206,6 +206,7 @@
 #ws_callflow .tools .inactive .open,
 .callflow-preview .tools .inactive .open{
 	background-image: url(static/images/arrow_inactive.png);
+	cursor: pointer;
 }
 
 #ws_callflow .tools .tool,
@@ -544,6 +545,7 @@
 #ws_callflow #ws_cf_flow,
 .callflow-preview #ws_cf_flow {
 	width: 100%;
+	min-height: 500px;
 	overflow-x: auto;
 	padding-top: 10px;
 	text-align: center;
@@ -622,6 +624,7 @@
 #ws_callflow .tools .search-box,
 .callflow-preview .tools .search-box {
 	background: #444;
+	position: relative;
 }
 
 #ws_callflow .tools .search-box input,
@@ -1724,4 +1727,10 @@
 
 .monster-button-duplicate {
 	margin-left: 10px !important;
+}
+
+#callflow_container .wrapper_callflow_buttons .disabled,
+.callflow-preview .wrapper_callflow_buttons .disabled {
+	pointer-events: none;
+	opacity: 0.6;
 }

--- a/style/icons.css
+++ b/style/icons.css
@@ -1326,3 +1326,13 @@
     background-position: -992px -448px;
 }
 
+.icon:not(.medium) {
+	margin-top: -10px;
+	padding-top: 10px;
+	background-origin: content-box;
+}
+
+.icon.medium {
+	margin-top: -2px;
+	padding-top: 2px;
+}


### PR DESCRIPTION
- Provides the ability to insert a Callflow action between existing items.
- Improved UX when deleting a Callflow action, where the action only supports a single child item then the action is deleted and the child items are moved up / reparented. Where an action supports multiple parallel child items then it and all child items are deleted - much like the previous handling.
- When deleting a Callflow action a confirmation message is now shown rather than simply deleting the action and its children. 
- Improved handling of terminating actions: Group Pickup, Receive Fax, Pivot, DISA, Response, Offnet, Resources. When adding these items they can only be added as a final child item, and not between existing items. 
- When adding an action to a Callflow, if any of the above terminating items are present then these are greyed out to prevent adding the action as a child item. 