### PR TITLE
WI#23803 - Expose Time of Day End Date

### DIFF
--- a/i18n/en-US.json
+++ b/i18n/en-US.json
@@ -584,6 +584,7 @@
 			"start_date_data_content": "Select the starting date of this rule",
 			"end_date": "End Date",
 			"end_date_data_content": "Select the ending date of this rule",
+			"end_date_less_than_start_date": "The end date must be greater than the start date.",
 			"enabled": "Enabled",
 			"enabled_data_content": "Select when this rule should be enabled",
 			"enabled_based_on_time": "Based on time",

--- a/submodules/timeofday/timeofday.js
+++ b/submodules/timeofday/timeofday.js
@@ -361,9 +361,15 @@ define(function(require) {
 
 						form_data.interval = $('#cycle', timeofday_html).val() === 'monthly' ? $('#interval_month', timeofday_html).val() : $('#interval_week', timeofday_html).val();
 						form_data.start_date = timeofday_html.find('#start_date').datepicker('getDate');
+
+						$(form_data.end_date !== '', timeofday_html).each(function() {
+							form_data.end_date = timeofday_html.find('#end_date').datepicker('getDate');
+						});
+
 						form_data = self.timeofdayCleanFormData(form_data);
 
 						self.timeofdaySave(form_data, data, callbacks.save_success);
+
 					} else {
 						$this.removeClass('disabled');
 						monster.ui.alert('error', self.i18n.active().callflows.timeofday.there_were_errors_on_the_form);
@@ -384,6 +390,26 @@ define(function(require) {
 
 				$('input.timepicker', timeofday_html).val('');
 				$('.time-wrapper', timeofday_html).toggleClass('hidden', $this.is(':checked'));
+			});
+
+			// if start date is null prefill with todays date
+			$('#start_date', timeofday_html).each(function() {
+				if (!$(this).val()) {
+					$(this).val(monster.util.toFriendlyDate(new Date(), 'date'));
+				}
+			});
+
+			// end date must be greater than start date
+			$('#end_date', timeofday_html).change(function() {
+			
+				startDate = timeofday_html.find('#start_date').datepicker('getDate');
+				endDate = timeofday_html.find('#end_date').datepicker('getDate');
+
+				if (endDate <= startDate) {
+					$('#end_date', timeofday_html).val('');
+					monster.ui.alert('warning', self.i18n.active().callflows.timeofday.end_date_less_than_start_date);
+				}
+
 			});
 
 			_after_render = callbacks.after_render;
@@ -430,6 +456,10 @@ define(function(require) {
 				form_data.start_date = monster.util.dateToBeginningOfGregorianDay(form_data.start_date, monster.util.getCurrentTimeZone());
 			}
 
+			if (form_data.end_date !== '') {
+				form_data.end_date = monster.util.dateToBeginningOfGregorianDay(form_data.end_date, monster.util.getCurrentTimeZone());
+			}
+
 			form_data.time_window_start = parseInt(monster.util.timeToSeconds(timeStart));
 			form_data.time_window_stop = parseInt(monster.util.timeToSeconds(timeEnd));
 
@@ -460,6 +490,10 @@ define(function(require) {
 			delete form_data.time;
 			delete form_data.weekday;
 
+			if (form_data.end_date === '') {
+				delete form_data.end_date;
+			}
+		
 			if (form_data.enabled === 'true') {
 				form_data.enabled = true;
 			} else if (form_data.enabled === 'false') {

--- a/submodules/timeofday/views/callflowEdit.html
+++ b/submodules/timeofday/views/callflowEdit.html
@@ -108,14 +108,12 @@
 						</div>
 					</div>
 
-				{{#if data.end_date}}
 					<div class="clearfix">
 						<label for="day">{{ i18n.callflows.timeofday.end_date }}</label>
 						<div class="input">
 							<input class="span4" id="end_date" name="end_date" type="text" placeholder="" value="{{ toFriendlyDate data.end_date "date"}}" rel="popover" data-content="{{ i18n.callflows.timeofday.end_date_data_content }}"{{#unless data.showSave}} disabled{{/unless}} />
 						</div>
 					</div>
-				{{/if}}
 
 					<div class="clearfix time-wrapper-field">
 						<label for="time">{{ i18n.callflows.timeofday.time }}</label>


### PR DESCRIPTION
End Date now exposed on the Time of Day form - not just when present on the doc.

![image](https://github.com/Dimensions-Technologies/monster-ui-callflows/assets/151521236/82b121ff-a493-404f-bb20-ea145946f4b3)

Added handling on End Date field on change events, so End Date is checked against Start Date that Start Date is not less than or equal to End Date. 

Warning message is shown if the End Date is less than or equal to Start Date and the End Date field is set to null so the incorrect value value can't be saved down.  

![image](https://github.com/Dimensions-Technologies/monster-ui-callflows/assets/151521236/120ee1ae-88a0-4594-bcd3-2bcae16c0b05)

Added JS so when creating a new rule Start Date is pre-populate with todays date as this is a required field. 
