### PR TITLE
WI#23823 - Fix Dragging Order

### DIFF
--- a/style/app.css
+++ b/style/app.css
@@ -474,10 +474,11 @@
 	float: left;
 }
 
-#callflow-content .ui-draggable-dragging {
+.callflow-content .ui-draggable-dragging {
 	cursor: -moz-grabbing !important;
 	cursor: -webkit-grabbing !important;
 	cursor: grabbing !important;
+	z-index: 999 !important;
 }
 
 #ws_callflow .root .top_bar .edit_icon,


### PR DESCRIPTION
When dragging an item it goes behind other actions. 

![UI-Draggable-1](https://github.com/Dimensions-Technologies/monster-ui-callflows/assets/151521236/ad3ab202-f5d4-4532-8916-4e3de016ec71)


After fixing class and applying z-index the dragged item is always in front of other actions. 

![UI-Draggable-2](https://github.com/Dimensions-Technologies/monster-ui-callflows/assets/151521236/96582c10-af9a-483e-9d80-ccbce2c48fca)

