### PR TITLE
WI#23838 - Pivot Timeout

### DIFF
--- a/i18n/en-US.json
+++ b/i18n/en-US.json
@@ -1339,6 +1339,8 @@
 		"add_a_user": "Add a user",
 		"select_user_title": "Select User",
 		"t_38_checkbox": "Enable T.38?",
+		"pivot_timeout": "Request Timeout (s)",
+		"pivot_timeout_invalid": "Invalid Request Timeout value.<br>The Request Timeout value must be between 5 and 20 seconds.",
 		"voice_url": "Voice URL",
 		"method": "Method",
 		"format": "Format",

--- a/submodules/misc/misc.js
+++ b/submodules/misc/misc.js
@@ -797,9 +797,9 @@ define(function(require) {
 					module: 'pivot',
 					tip: self.i18n.active().oldCallflows.pivot_tip,
 					data: {
-						method: 'get',
+						method: 'POST',
 						req_timeout: '5',
-						req_format: 'twiml',
+						req_format: 'kazoo',
 						voice_url: ''
 					},
 					rules: [
@@ -820,10 +820,10 @@ define(function(require) {
 							name: 'pivot',
 							data: {
 								data_pivot: {
-									'method': node.getMetadata('method') || 'get',
+									'method': node.getMetadata('method') || 'post',
 									'voice_url': node.getMetadata('voice_url') || '',
 									'req_timeout': node.getMetadata('req_timeout') || '5',
-									'req_format': node.getMetadata('req_format') || 'twiml'
+									'req_format': node.getMetadata('req_format') || 'kazoo'
 								}
 							},
 							submodule: 'misc'
@@ -833,6 +833,7 @@ define(function(require) {
 							node.setMetadata('voice_url', $('#pivot_voiceurl_input', popup_html).val());
 							node.setMetadata('method', $('#pivot_method_input', popup_html).val());
 							node.setMetadata('req_format', $('#pivot_format_input', popup_html).val());
+							node.setMetadata('req_timeout', $('#pivot_timeout_input', popup_html).val());
 
 							popup.dialog('close');
 						});
@@ -846,6 +847,21 @@ define(function(require) {
 								}
 							}
 						});
+
+						// alert for invalid request timeout value
+						$('#pivot_timeout_input', popup_html).change(function() {
+						
+							requestTimeout = $('#pivot_timeout_input', popup_html).val();
+
+							if (requestTimeout < 5 || requestTimeout > 20) {
+								$('#pivot_timeout_input', popup_html).val(5);
+								monster.ui.alert('warning', self.i18n.active().oldCallflows.pivot_timeout_invalid);
+								console.log('invalid timeout')
+							}
+						
+						});
+
+
 					}
 				},
 				'disa[]': {

--- a/submodules/misc/views/pivot.html
+++ b/submodules/misc/views/pivot.html
@@ -9,7 +9,7 @@
 
 			<div class="popup_field">
 				<label for="pivot_method_input">{{ i18n.oldCallflows.method }}: </label>
-				<select id="pivot_method_input" style="width: 100px; height: 28px;">
+				<select id="pivot_method_input">
 					{{#compare data_pivot.method "===" "POST"}}
 						<option value="POST" selected="selected">POST</option>
 						<option value="GET">GET</option>
@@ -22,7 +22,7 @@
 
 			<div class="popup_field">
 				<label for="pivot_format_input">{{ i18n.oldCallflows.format }}: </label>
-				<select id="pivot_format_input" style="width: 100px; height: 28px;">
+				<select id="pivot_format_input">
 					{{#compare data_pivot.req_format "===" "twiml"}}
 						<option value="twiml" selected="selected">twiml</option>
 						<option value="kazoo">Kazoo</option>
@@ -31,6 +31,11 @@
 						<option value="kazoo" selected="selected">Kazoo</option>
 					{{/compare}}
 				</select>
+			</div>
+
+			<div class="popup_field">
+				<label for="pivot_timeout_input">{{ i18n.oldCallflows.pivot_timeout }}: </label>
+				<input type="number" min="5" step="1" max="20" id="pivot_timeout_input" class="medium" value="{{data_pivot.req_timeout}}"/>
 			</div>
 		</div>
 	</form>


### PR DESCRIPTION
Pivot action provides no ability to set the timeout value - defaults to 5 seconds when created. 

![image](https://github.com/Dimensions-Technologies/monster-ui-callflows/assets/151521236/9f43b95c-6af9-4ee0-ac29-9a114611bc6e)


Added timeout field that defaults to 5, but will accept any full number value between 5 and 20.

![image](https://github.com/Dimensions-Technologies/monster-ui-callflows/assets/151521236/fe5b25fd-79de-4519-8555-40f33b1fab44)

Should the value entered be outside of this range a warning message is shown and the value is reverted to 5

![image](https://github.com/Dimensions-Technologies/monster-ui-callflows/assets/151521236/bd991e9a-e763-4915-b9de-51421dda43c3)


