### PR TITLE
WI#23709 - Enhance Child Action Control

### DIFF
--- a/app.js
+++ b/app.js
@@ -1202,6 +1202,32 @@ define(function(require) {
 					return list;
 				};
 
+				this.allowedChildren = function() {
+					
+					var children;
+
+					for (var i in action.rules) {
+						var rule = action.rules[i];
+
+						if (rule.type === 'allowedChildren') {
+							var children = rule.action;
+						}
+					}
+
+					return children;
+				};
+
+				this.terminatingAction = function() {
+				
+					var actionName = Object(action).key;
+					var isTerminating = action.isTerminating;
+
+					return {
+						actionName: actionName,
+						isTerminating: isTerminating
+					}
+				};
+
 				this.contains = function(branch) {
 					var toCheck = branch;
 
@@ -2218,23 +2244,16 @@ define(function(require) {
 
 		enableDestinations: function(el) {
 			
-			var terminatingActionNames = [
-				'group_pickup[]',
-				'receive_fax[]',
-				'pivot[]',
-				'disa[]',
-				'response[]',
-				'offnet[]',
-				'resources[]'
-			],
-				self = this;
+			self = this;
 
 			$('.node').each(function() {
 
-				var actionName = el.attr('name')
-				
+				var actionName = el.attr('name'),
+					action = self.actions[actionName],
+					target = self.flow.nodes[$(this).attr('id')];
+			
 				// prevent inserting callflow action where selected action is a terminating action
-				if (terminatingActionNames.includes(actionName)) {
+				if (action.isTerminating == 'true' && target.terminatingAction().isTerminating != 'true') {
 
 					var activate = true,
 						target = self.flow.nodes[$(this).attr('id')];
@@ -2261,9 +2280,12 @@ define(function(require) {
 					var activate = true,
 						target = self.flow.nodes[$(this).attr('id')];
 
-					// prevent adding callflow action after a terminating action
-					if (terminatingActionNames.includes(target.actionName)) {
-						if (el.attr('name') in target.potentialChildren()) {
+					// prevent adding child actions to a terminating action
+					if (target.terminatingAction().isTerminating == 'true') {
+
+						// added support for new rule type of allowedChildren - allows adding callflow as child action of pivot as an example
+						if (el.attr('name') in target.potentialChildren() && Array.isArray(target.allowedChildren()) && target.allowedChildren().includes(el.attr('name'))) {
+
 							if (el.hasClass('node') && self.flow.nodes[el.attr('id')].contains(target)) {
 								activate = false;
 							}
@@ -2276,7 +2298,8 @@ define(function(require) {
 						} else {
 							$(this).addClass('inactive');
 							$(this).droppable('disable');
-						}
+						}	
+
 					}
 
 				}

--- a/submodules/misc/misc.js
+++ b/submodules/misc/misc.js
@@ -81,6 +81,7 @@ define(function(require) {
 							maxSize: '1'
 						}
 					],
+					isTerminating: 'true',
 					isUsable: 'true',
 					weight: 20,
 					caption: function(node, caption_map) {
@@ -584,6 +585,7 @@ define(function(require) {
 							maxSize: '0'
 						}
 					],
+					isTerminating: 'true',
 					isUsable: 'true',
 					weight: 60,
 					caption: function(node) {
@@ -645,6 +647,7 @@ define(function(require) {
 							maxSize: '0'
 						}
 					],
+					isTerminating: 'true',
 					isUsable: 'true',
 					weight: 70,
 					caption: function(node) {
@@ -805,9 +808,16 @@ define(function(require) {
 					rules: [
 						{
 							type: 'quantity',
-							maxSize: '0'
+							maxSize: '1'
+						},
+						{
+							type: 'allowedChildren',
+							action: [
+								'callflow[id=*]'
+							]
 						}
 					],
+					isTerminating: 'true',
 					isUsable: 'true',
 					weight: 80,
 					caption: function(node) {
@@ -880,6 +890,7 @@ define(function(require) {
 							maxSize: '0'
 						}
 					],
+					isTerminating: 'true',
 					isUsable: 'true',
 					weight: 90,
 					caption: function(node) {
@@ -1151,6 +1162,7 @@ define(function(require) {
 							maxSize: '0'
 						}
 					],
+					isTerminating: 'true',
 					isUsable: 'true',
 					weight: 100,
 					caption: function(node) {

--- a/submodules/resource/resource.js
+++ b/submodules/resource/resource.js
@@ -28,6 +28,7 @@ define(function(require) {
 							maxSize: '0'
 						}
 					],
+					isTerminating: 'true',
 					isUsable: 'true',
 					weight: 140,
 					caption: function(node) {
@@ -52,6 +53,7 @@ define(function(require) {
 							maxSize: '0'
 						}
 					],
+					isTerminating: 'true',
 					isUsable: 'true',
 					weight: 150,
 					caption: function(node) {


### PR DESCRIPTION
Enhanced handling of Callflow child actions. 

Added a new property to Callflow actions:

`isTerminating: 'true'`

This is used to identify if a Callflow action is an end event. 
If 'true' is returned then the Callflow action can't be inserted within a Callflow, and can only be added as an end event. 

Support for additional rule added to Callflow action:

```
{
  type: 'allowedChildren',
  action: [
    'callflow[id=*]'
  ]
} 
```

This is used in conjunction with 'isTerminating' and will allow the Callflow actions listed to be added as child actions. 
Note: 'action' must be an array. 

This was specifically added to allow a Callflow child action to be added to a Pivot action, which is an end event. Pivot does support a child action which acts as a fallback destination should the Pivot request timeout. This however was not configurable through the UI. With the addition of the above this can now be configured through Callflows Plus. 

![pivot-child_action](https://github.com/Dimensions-Technologies/monster-ui-callflows/assets/151521236/d58c677c-a60a-4a13-8746-eb7cd8c94b94)






