### PR TITLE
WI#23859 - View/Change DND on User

### DIFF
--- a/i18n/en-US.json
+++ b/i18n/en-US.json
@@ -809,7 +809,11 @@
 			"caller_id_number_data_content4": "Define the Caller ID Number of this User, to be used for P-Asserted-Identity header.",
 			"caller_id_realm": "Caller ID Realm",
 			"caller_id_realm_placeholder": "Realm",
-			"caller_id_realm_data_content4": "Define the Caller ID Realm of this User, to be used for P-Asserted-Identity header."
+			"caller_id_realm_data_content4": "Define the Caller ID Realm of this User, to be used for P-Asserted-Identity header.",
+			"do_not_disturb": "Do Not Disturb (DND)",
+			"do_not_disturb_status": "DND Status",
+			"do_not_disturb_status_true": "Enabled",
+			"do_not_disturb_status_false": "Disabled"
 		},
 		"vmbox": {
 			"voicemail": "Voicemail",

--- a/submodules/user/user.js
+++ b/submodules/user/user.js
@@ -1241,6 +1241,11 @@ define(function(require) {
 				data.password = monster.util.randomString(8, 'safe');
 			}
 
+			// add support for setting dnd on user doc
+			data.do_not_disturb = {
+				enabled: data.do_not_disturb.enabled
+			}
+
 			return data;
 		},
 

--- a/submodules/user/views/edit.html
+++ b/submodules/user/views/edit.html
@@ -92,6 +92,19 @@
 
 				<hr />
 
+				<h3>{{ i18n.callflows.user.do_not_disturb }}</h3>
+				<div class="clearfix">
+					<label for="do_not_disturb">{{ i18n.callflows.user.do_not_disturb_status }}</label>
+					<div class="input">
+						<select id="do_not_disturb.enabled" name="do_not_disturb.enabled" class="medium" rel="popover">
+							<option value="false"{{#compare data.do_not_disturb.enabled '===' false}} selected{{/compare}}>{{ i18n.callflows.user.do_not_disturb_status_false }}</option>
+							<option value="true"{{#compare data.do_not_disturb.enabled '===' true}} selected{{/compare}}>{{ i18n.callflows.user.do_not_disturb_status_true }}</option>
+						</select>
+					</div>
+				</div>
+
+				<hr />
+
 				<h3>{{ i18n.callflows.user.in_house_calls }}</h3>
 				<div class="clearfix">
 					<label for="caller_id_name_internal">{{ i18n.callflows.user.caller_id_name }}</label>


### PR DESCRIPTION
Provide the ability to view and edit DND status on a User within Callflows removing the need to go to SmartPBX to view and edit this. 

![image](https://github.com/Dimensions-Technologies/monster-ui-callflows/assets/151521236/b6d7989d-a25e-4f82-aca0-dd6a3fb30938)
