### PR TITLE
WI#23949 - Conditionally Hide Time of Day End Date

### DIFF
--- a/i18n/en-US.json
+++ b/i18n/en-US.json
@@ -582,7 +582,7 @@
 			"date_data_content": "Select the date of this rule",
 			"start_date": "Start Date",
 			"start_date_data_content": "Select the starting date of this rule",
-			"end_date": "End Date",
+			"end_date": "End Date (inclusive)",
 			"end_date_data_content": "Select the ending date of this rule",
 			"end_date_less_than_start_date": "The end date must be greater than the start date.",
 			"enabled": "Enabled",

--- a/submodules/timeofday/timeofday.js
+++ b/submodules/timeofday/timeofday.js
@@ -243,14 +243,19 @@ define(function(require) {
 			$('#days_checkboxes', timeofday_html).hide();
 			$('#weekdays', timeofday_html).hide();
 			$('#specific_day', timeofday_html).hide();
+			$('#date_range_end', timeofday_html).show();
 
 			if (data.data.id === undefined) {
 				$('#every', timeofday_html).hide();
 				$('#on', timeofday_html).hide();
 			} else {
-				if (data.data.cycle === 'daily' || data.data.cycle === 'date') {
+				if (data.data.cycle === 'daily') {
 					$('#every', timeofday_html).hide();
 					$('#on', timeofday_html).hide();
+				} else if (data.data.cycle === 'date') {
+					$('#every', timeofday_html).hide();
+					$('#on', timeofday_html).hide();
+					$('#date_range_end', timeofday_html).hide();
 				} else if (data.data.cycle === 'monthly') {
 					$('#monthly_every', timeofday_html).show();
 					$('#ordinal', timeofday_html).show();
@@ -298,6 +303,7 @@ define(function(require) {
 
 			$('#cycle', timeofday_html).change(function() {
 				var $this = $(this);
+					form_data = monster.ui.getFormData('timeofday-form');
 
 				$('#yearly_every', timeofday_html).hide();
 				$('#monthly_every', timeofday_html).hide();
@@ -308,6 +314,7 @@ define(function(require) {
 				$('#specific_day', timeofday_html).hide();
 				$('#every', timeofday_html).show();
 				$('#on', timeofday_html).show();
+				$('#date_range_end', timeofday_html).show();
 
 				if ($this.val() === 'yearly') {
 					$('#yearly_every', timeofday_html).show();
@@ -332,9 +339,15 @@ define(function(require) {
 				} else if ($this.val() === 'weekly') {
 					$('#weekly_every', timeofday_html).show();
 					$('#days_checkboxes', timeofday_html).show();
-				} else if ($this.val() === 'daily' || $this.val() === 'date') {
+				} else if ($this.val() === 'daily') {
 					$('#every', timeofday_html).hide();
 					$('#on', timeofday_html).hide();
+				} else if ($this.val() === 'date') {
+					$('#every', timeofday_html).hide();
+					$('#on', timeofday_html).hide();
+					$('#date_range_end', timeofday_html).hide();
+					$('#end_date', timeofday_html).val(null);
+					delete(form_data.end_date);					
 				}
 			});
 

--- a/submodules/timeofday/views/callflowEdit.html
+++ b/submodules/timeofday/views/callflowEdit.html
@@ -108,13 +108,13 @@
 						</div>
 					</div>
 
-					<div class="clearfix">
+					<div class="clearfix" id="date_range_end">
 						<label for="day">{{ i18n.callflows.timeofday.end_date }}</label>
 						<div class="input">
 							<input class="span4" id="end_date" name="end_date" type="text" placeholder="" value="{{ toFriendlyDate data.end_date "date"}}" rel="popover" data-content="{{ i18n.callflows.timeofday.end_date_data_content }}"{{#unless data.showSave}} disabled{{/unless}} />
 						</div>
 					</div>
-
+					
 					<div class="clearfix time-wrapper-field">
 						<label for="time">{{ i18n.callflows.timeofday.time }}</label>
 						<div class="input time-wrapper{{#if field_data.isAllDay}} hidden{{/if}}">


### PR DESCRIPTION
End Date does not work if Repeats is set to 'Date' 
'Date' is a single date, so the End Date field should be hidden. 

Label on End Date should be updated to ' End Date (inclusive) ' so it's clear that the date value in the end date field is included in the range.  