### PR TITLE
Story/24721-2 - Check Emergency Caller ID is Set

### DIFF
--- a/i18n/en-US.json
+++ b/i18n/en-US.json
@@ -1248,7 +1248,14 @@
 				"label": "Custom data (optional)",
 				"help": "These properties will be added to the event and will overwrite existing values"
 			}
+		},
+
+		"uk999": {
+			"emergencyCallerIdNotSet": "The Emergency Caller ID has not been set for this account. Please set this under 'Account Settings'. If the customer has multiple locations please ensure you set the correct Emergency Caller ID at User level where this is different to the main account Emergency Caller ID.",
+			"emergencyCallerIdAddressNotSet": "The Emergency Caller ID that has been set does not have an address set against it. Please set the address against the number from within the Numbers App."
+
 		}
+
 	},
 	"oldCallflows": {
 		"call_forwarding_cat": "Call Forwarding",


### PR DESCRIPTION
- Show an alert of the Emergency Caller ID has not been set when first loading the app. 
- Show an alert if the address has not been set against the Emergency Caller ID if the Reseller is uk999 enabled.