### PR TITLE
WI#25240 - Ability to Add DDI Numbers to User Directly

### DIFF
--- a/i18n/en-US.json
+++ b/i18n/en-US.json
@@ -279,7 +279,11 @@
 					"number": "Please enter a valid phone number",
 					"realm": "Please enter a valid realm"
 				}
-			}
+			},
+			"phone_numbers": "Phone Numbers",
+			"phone_numbers_options": "Assigned Phone Numbers",
+			"phone_numbers_add": "Add Phone Number",
+			"phone_numbers_none": "This device currently has no assigned phone numbers"
 		},
 		"disa": {
 			"title": "DISA",
@@ -837,7 +841,11 @@
 			"do_not_disturb": "Do Not Disturb (DND)",
 			"do_not_disturb_status": "DND Status",
 			"do_not_disturb_status_true": "Enabled",
-			"do_not_disturb_status_false": "Disabled"
+			"do_not_disturb_status_false": "Disabled",
+			"phone_numbers": "Phone Numbers",
+			"phone_numbers_options": "Assigned Phone Numbers",
+			"phone_numbers_add": "Add Phone Number",
+			"phone_numbers_none": "This user currently has no assigned phone numbers"
 		},
 		"vmbox": {
 			"voicemail": "Voicemail",

--- a/submodules/device/device.css
+++ b/submodules/device/device.css
@@ -139,3 +139,41 @@
 .core-content .inline_popup #device-form .items-selector .box-selector .box-content {
    width: 70%;
 }
+
+/* phone numbers tab formatting */
+.callflows-port #device-form #phone_numbers #phone_numbers_container .numberRows .row {
+	margin-left: 0px;
+}
+
+/* phone numbers tab formatting */
+.callflows-port #device-form #phone_numbers .item-row .number-container {
+    min-width: 237px;
+	display: flex;
+}
+
+/* phone numbers tab formatting */
+.callflows-port #device-form #phone_numbers .item-row .number-container .number .phone-number-label {
+    text-align: left;
+}
+
+/* phone numbers tab formatting */
+.callflows-port #device-form #phone_numbers .item-row>* {
+    display: inline-block;
+    padding: 10px;
+    height: 32px;
+    line-height: 32px;
+}
+
+/* phone numbers tab formatting */
+.callflows-port #device-form #phone_numbers .item-row button {
+    margin-right: 25px;
+	text-align: center;
+	line-height: 10px;
+}
+
+/* phone numbers tab formatting */
+.callflows-port #device-form #phone_numbers .number-addition {
+	padding-top: 20px;
+	display: flex;
+    justify-content: flex-end;
+}

--- a/submodules/device/device.js
+++ b/submodules/device/device.js
@@ -181,6 +181,10 @@ define(function(require) {
 								}
 							}
 						},
+						device_callflow: null,
+						phone_numbers: [],
+						extension_numbers: [],
+						callflow_numbers: [],
 						hide_owner: data.hide_owner || false,
 						outbound_flags: data.outbound_flags ? data.outbound_flags.join(', ') : data.outbound_flags
 					},
@@ -195,7 +199,99 @@ define(function(require) {
 					}
 				},
 				parallelRequests = function(deviceData) {
+
+					if (deviceData.hasOwnProperty('dimension') && deviceData.dimension.hasOwnProperty('type')) {
+						dimensionDeviceType[deviceData.dimension.type] = true;
+						dimensionDeviceType['preventDelete'] = true;
+					}
+
+					else {
+						dimensionDeviceType = {}
+					}
+
+					if (miscSettings.enableConsoleLogging) {
+						console.log(dimensionDeviceType)
+					}
+
 					monster.parallel(_.merge({
+
+						
+						get_callflow: function(callback) {
+
+							// if the device is classed as a communal get associated callflow
+							if ((dimensionDeviceType.communal == true || false) && (miscSettings.deviceShowCommunalPhoneNumbers == true || false)) {
+
+								self.callApi({
+									resource: 'callflow.list',
+									data: {
+										accountId: self.accountId,
+										filters: {
+											"filter_owner_id": deviceData.id
+										}
+									},
+									success: function(callflow) {
+			
+										if (callflow.data.length > 0 && callflow.data[0].numbers.length > 0) {
+			
+											// set callflow id for the user
+											defaults.field_data.device_callflow = callflow.data[0].id;
+									
+											// filter numbers to get phone numbers
+											var phoneNumbers = callflow.data[0].numbers.filter(function(number) {
+												if (miscSettings.fixedExtensionLength) {
+													return number.length > 7;
+												}
+												else {
+													return number.startsWith('+');
+												}
+											});
+			
+											var formattedPhoneNumbers = phoneNumbers.map(function(number) {
+												return number;
+											});
+			
+											// filter numbers to get extension numbers
+											var extensionNumbers = callflow.data[0].numbers.filter(function(number) {
+												if (miscSettings.fixedExtensionLength) {
+													return number.length <= 7;
+												}
+												else {
+													return !number.startsWith('+');
+												}
+											});
+								
+											var formattedExtensionNumbers = extensionNumbers.map(function(number) {
+												return number
+											});
+								
+											if (miscSettings.enableConsoleLogging) {
+												console.log('Callflow ID', callflow.data[0].id)
+												console.log('Phone Numbers', formattedPhoneNumbers)
+												console.log('Extension Numbers', formattedExtensionNumbers)
+											}
+										
+											defaults.field_data.callflow_numbers = callflow.data[0].numbers
+											defaults.field_data.phone_numbers = formattedPhoneNumbers;
+											defaults.field_data.extension_numbers = formattedExtensionNumbers;
+											
+										}
+			
+										callback(null, callflow);
+			
+									}
+								});
+
+							}
+
+							else {
+
+								callback(null);
+
+							}
+						
+						},
+						
+					
 						list_classifier: function(callback) {
 							self.callApi({
 								resource: 'numbers.listClassifiers',
@@ -558,6 +654,11 @@ define(function(require) {
 		},
 
 		deviceRender: function(data, target, callbacks) {
+
+			if (miscSettings.enableConsoleLogging) {
+				console.log('Device Data', data)
+			}
+
 			var self = this,
 				hasExternalCallerId = monster.util.getCapability('caller_id.external_numbers').isEnabled,
 				cidSelectors = [
@@ -655,6 +756,10 @@ define(function(require) {
 					self.deviceSetProvisionerStuff(device_html, data);
 				}
 
+				if ((dimensionDeviceType.communal == true || false) && (miscSettings.deviceShowCommunalPhoneNumbers == true || false)) {
+					self.deviceRenderNumberList(data, device_html);
+				}
+				
 				monster.ui.validate(deviceForm, self.deviceGetValidationByDeviceType(data.data.device_type));
 
 				if (!$('#owner_id', device_html).val()) {
@@ -707,6 +812,89 @@ define(function(require) {
 				trigger: 'focus'
 			});
 
+			if ((dimensionDeviceType.communal == true || false) && (miscSettings.deviceShowCommunalPhoneNumbers == true || false)) {
+				$('.add-phone-number', device_html).click(function(ev) {
+
+					ev.preventDefault();
+
+					var field_data = data.field_data;
+
+					self.listNumbers(function(phoneNumbers) {
+						var parsedNumbers = [];
+
+						// filter out numbers already added to the form but not yet saved
+						_.each(phoneNumbers, function(number) {
+							if ($.inArray(number.phoneNumber, field_data.phone_numbers) < 0) {	
+								parsedNumbers.push(number);
+							}
+						});
+
+						var popup_html = $(self.getTemplate({
+								name: 'addPhoneNumber',
+								data: {
+									phoneNumbers: parsedNumbers,
+									hideBuyNumbers: _.get(monster, 'config.whitelabel.hideBuyNumbers', false)
+								},
+								submodule: 'device'
+							})),
+							popup = monster.ui.dialog(popup_html, {
+								title: self.i18n.active().oldCallflows.add_number
+							});
+
+						monster.ui.chosen(popup_html.find('#list_numbers'), {
+							width: '160px'
+						});
+
+						// Have to do that so that the chosen dropdown isn't hidden.
+						popup_html.parent().css('overflow', 'visible');
+
+						if (parsedNumbers.length === 0) {
+							$('#list_numbers', popup_html).attr('disabled', 'disabled');
+							$('<option value="select_none">' + self.i18n.active().oldCallflows.no_phone_numbers + '</option>').appendTo($('#list_numbers', popup_html));
+						}
+
+						popup.find('.buy-link').on('click', function(e) {
+							e.preventDefault();
+							monster.pub('common.buyNumbers', {
+								searchType: $(this).data('type'),
+								callbacks: {
+									success: function(numbers) {
+										var lastNumber;
+
+										_.each(numbers, function(number, k) {
+											popup.find('#list_numbers').append($('<option value="' + k + '">' + monster.util.formatPhoneNumber(k) + '</option>'));
+											lastNumber = k;
+										});
+
+										popup.find('#list_numbers').val(lastNumber).trigger('chosen:updated');
+									}
+								}
+							});
+						});
+
+						$('.add_number', popup).click(function(event) {
+							
+							event.preventDefault();
+						
+							var number = $('input[name="number_type"]:checked', popup).val() === 'your_numbers' ? $('#list_numbers option:selected', popup).val() : $('#add_number_text', popup).val();
+						
+							// push number into field_data.numbers
+							field_data.phone_numbers.push(number);
+
+							if (miscSettings.enableConsoleLogging) {
+								console.log('Number Being Added:', number)
+							}
+
+							self.deviceRenderNumberList(data, device_html)
+						
+							popup.dialog('close');
+
+						});
+
+					});
+				});
+			}
+			
 			self.winkstartTabs(device_html);
 
 			self.deviceBindEvents({
@@ -1196,7 +1384,7 @@ define(function(require) {
 			}
 
 			// add support for setting dnd doc for phone only devices
-			if (dimensionDeviceType == 'communal') {
+			if ((dimensionDeviceType.communal == true || false) && (miscSettings.deviceShowCommunalPhoneNumbers == true || false)) {
 				data.do_not_disturb = {
 					enabled: data.do_not_disturb.enabled
 				}
@@ -1345,6 +1533,49 @@ define(function(require) {
 
 		deviceSave: function(form_data, data, success) {
 
+			if ((dimensionDeviceType.communal == true || false) && (miscSettings.deviceShowCommunalPhoneNumbers == true || false)) {
+				var	self = this, 
+					callflowNumbers = data.field_data.callflow_numbers,
+					formNumbers = (data.field_data.extension_numbers || []).concat(form_data.phone_numbers || []),
+					deviceCallflow = data.field_data.device_callflow;
+
+				if (miscSettings.enableConsoleLogging) {
+					console.log('Numbers on User Callflow', callflowNumbers);
+					console.log('Numbers on User Form', formNumbers);
+				}
+
+				if ('callflow_numbers' in form_data) {
+					delete form_data.callflow_numbers;
+				}
+
+				if ('phone_numbers' in form_data) {
+					delete form_data.phone_numbers;
+				}
+
+				if ('extension_numbers' in form_data) {
+					delete form_data.extension_numbers;
+				}
+
+				// patch users callflow if there is a change to the qty of numbers
+				if (formNumbers.length > 0 && formNumbers.length != callflowNumbers.length) {
+					self.callApi({
+						resource: 'callflow.patch',
+						data: {
+							accountId: self.accountId,
+							callflowId: deviceCallflow,
+							data: {
+								numbers: formNumbers
+							}
+						},
+						success: function(_callflow_update) {
+							if (miscSettings.enableConsoleLogging) {
+								console.log('Device Callflow Updated', _callflow_update)
+							}
+						}
+					})
+				}
+			}
+
 			var self = this,
 				id = (typeof data.data === 'object' && data.data.id) ? data.data.id : undefined,
 				normalized_data = self.deviceFixArrays(self.deviceNormalizeData($.extend(true, {}, data.data, form_data)), form_data);
@@ -1358,6 +1589,7 @@ define(function(require) {
 					success && success(_data, status, 'create');
 				});
 			}
+
 		},
 
 		deviceList: function(callback) {
@@ -1631,7 +1863,65 @@ define(function(require) {
 					editEntity: 'callflows.device.edit'
 				}
 			});
+		},
+
+		deviceRenderNumberList: function(data, parent) {
+			var self = this,
+				parent = $('#phone_numbers_container', parent);
+
+				if (miscSettings.enableConsoleLogging) {
+					console.log('Device Data', data)
+				}
+
+				var phone_numbers = data.field_data.phone_numbers
+
+				$('.numberRows', parent).empty();
+
+				var numberRow_html = $(self.getTemplate({
+					name: 'numberRow',
+					data: {
+						phone_numbers
+					},
+					submodule: 'device'
+				}));
+
+				$('.numberRows', parent).append(numberRow_html);
+
+				$('.unassign-phone-number', numberRow_html).click(function(ev) {
+
+					ev.preventDefault();
+	
+					// find the hidden input field within the same .number-container
+					var phoneNumberValue = $(this).closest('.number-container').find('input[type="hidden"]').val(),
+						field_data = data.field_data;
+					
+					// remove the phone number from the field data array
+					field_data.phone_numbers = field_data.phone_numbers.filter(function(number) {
+						return number !== phoneNumberValue;
+					});
+	
+					var row = $(this).closest('.item-row'),
+						hr = row.next('hr');
+	
+					// slide up and remove the item row and the <hr> element
+					row.add(hr).slideUp(function() {
+						row.add(hr).remove();
+	
+						if (!device_html.find('.number-container .item-row').is(':visible')) {
+							device_html.find('.number-container .empty-row').slideDown();
+						}
+	
+					});
+	
+					if (miscSettings.enableConsoleLogging) {
+						console.log('Phone Number Being Removed:', phoneNumberValue);
+						console.log('Field Data', field_data);
+					}
+					
+				})
+				
 		}
+
 	};
 
 	return app;

--- a/submodules/device/views/addPhoneNumber.html
+++ b/submodules/device/views/addPhoneNumber.html
@@ -1,0 +1,49 @@
+<div class="dialog_popup_new add_number_popup">
+	<form class="form-inline">
+		<div class="popup_field">
+			<input type="radio" id="number_type_1" name="number_type" value="your_numbers" checked="checked" style="display: none;"></input>
+			<label for="number_type_1">{{ i18n.oldCallflows.available_numbers }}</label>
+
+			<div class="list_numbers_content">
+				<select id="list_numbers">
+					{{#each phoneNumbers}}
+						<option value="{{ this.phoneNumber }}">{{ formatPhoneNumber this.phoneNumber }}</option>
+					{{/each}}
+				</select>
+
+				<ul class="nav pull-right number-selection-sidelink">
+					{{#unless hideBuyNumbers}}
+					<li class="dropdown">
+						<a href="#" class="dropdown-toggle buy-dropdown monster-link" data-toggle="dropdown" data-target="#">
+							<i class="fa fa-shopping-cart monster-green fa-lg"></i>
+							{{ i18n.callflows.buyNumbers }}
+						</a>
+						<ul class="dropdown-menu" role="menu">
+							<li><a class="buy-link" data-type="regular" href="#">{{ i18n.callflows.buyLocal }}</a></li>
+							<li><a class="buy-link" data-type="tollfree" href="#">{{ i18n.callflows.buyTollfree }}</a></li>
+							<!-- <li><a class="buy-link" data-type="vanity" href="#">{{ i18n.callflows.buyVanity }}</a></li> -->
+						</ul>
+					</li>
+					{{/unless}}
+				</ul>
+				
+			</div>
+		</div>
+
+		<!--
+		<div class="popup_field">
+			<input type="radio" id="number_type_2" name="number_type" value="extension"></input>
+			<label for="number_type_2">{{ i18n.oldCallflows.extension }}</label>
+
+			<div class="extensions_content">
+				<input id="add_number_text" placeholder="2001" type="text" name="number"/>
+				<a href="javascript:void(0);" class="number-selection-sidelink search-extension-link">{{ i18n.callflows.findExtension }}</a>
+			</div>
+		</div>
+		-->
+		
+		<div class="buttons">
+			<button class="monster-button monster-button-primary add_number">{{ i18n.oldCallflows.add }}</button>
+		</div>
+	</form>
+</div>

--- a/submodules/device/views/device-sip_device.html
+++ b/submodules/device/views/device-sip_device.html
@@ -17,6 +17,11 @@
 		<ul class="tabs" data-tabs="tabs">
 			<li class="active"><a href="#basic">{{ i18n.callflows.device.basic }}</a></li>
 			<li><a href="#caller_id">{{ i18n.callflows.device.caller_id }}</a></li>
+			{{#if miscSettings.deviceShowCommunalPhoneNumbers}}
+			{{#if dimensionDeviceType.communal}}
+				<li><a href="#phone_numbers">{{ i18n.callflows.device.phone_numbers }}</a></li>
+			{{/if}}
+			{{/if}}
 			{{#unless miscSettings.hideDeviceSipSettings}}
 				<li><a href="#sip_settings">{{ i18n.callflows.device.sip }}</a></li>
 			{{/unless}}
@@ -307,7 +312,7 @@
 						{{/unless}}
 						{{#if miscSettings.deviceReadOnlyFields}}
 							<div class="input">
-								<input disabled class="span4 input-readonly" id="presence_id" name="presence_id" type="text" />
+								<input disabled class="span4 input-readonly" id="presence_id" name="presence_id" type="text" value="{{data.presence_id}}" />
 							</div>
 						{{/if}}
 					</div>
@@ -336,7 +341,7 @@
 						{{/unless}}
 						{{#if miscSettings.deviceReadOnlyFields}}
 							<div class="input">
-								<input disabled class="span4 input-readonly" id="caller_id_number_internal" name="caller_id.internal.number" type="text" />
+								<input disabled class="span4 input-readonly" id="caller_id_number_internal" name="caller_id.internal.number" type="text" value="{{data.caller_id.internal.number}}" />
 							</div>
 						{{/if}}
 					</div>
@@ -464,6 +469,21 @@
 				{{/if}}
 
 
+				</div>
+				
+
+				<div id="phone_numbers">
+					<h3>{{ i18n.callflows.user.phone_numbers_options }}</h3>
+				
+					<div id="phone_numbers_container">
+						<!-- placeholder for numberRow.html -->
+						<div class="numberRows">
+						</div>
+					</div>
+				
+					<div class="number-addition">
+						<button class="monster-button add-phone-number">{{ i18n.callflows.user.phone_numbers_add }}</button>
+					</div>
 				</div>
 				
 

--- a/submodules/device/views/numberRow.html
+++ b/submodules/device/views/numberRow.html
@@ -1,0 +1,24 @@
+<div class="row">
+    {{#if phone_numbers}}
+    <div id="phone_numbers_container">
+        {{#each phone_numbers}}
+        <div class="item-row">
+            
+            <div class="number-container">
+                <button type="button" class="monster-button monster-button-danger unassign-phone-number">{{ @root.i18n.unassign }}</button>
+                
+                <span class="number">
+                    <label class="phone-number-label">{{ formatPhoneNumber this }}</label>
+                    <input id="phone_numbers" name="phone_numbers[]" type="hidden" value="{{ this }}" />
+                </span>
+                                
+            </div>
+
+        </div>
+        <hr>
+        {{/each}}
+    </div>
+    {{else}}
+	    <div class="phone-numbers-none">{{ i18n.callflows.device.phone_numbers_none }}</div>
+    {{/if}}
+</div>

--- a/submodules/user/user.css
+++ b/submodules/user/user.css
@@ -169,3 +169,41 @@
 .callflows-port #user-form #hotdesk_devices .row input[type="checkbox"] {
 	margin-top: 10px;
 }
+
+/* phone numbers tab formatting */
+.callflows-port #user-form #phone_numbers #phone_numbers_container .numberRows .row {
+	margin-left: 0px;
+}
+
+/* phone numbers tab formatting */
+.callflows-port #user-form #phone_numbers .item-row .number-container {
+    min-width: 237px;
+	display: flex;
+}
+
+/* phone numbers tab formatting */
+.callflows-port #user-form #phone_numbers .item-row .number-container .number .phone-number-label {
+    text-align: left;
+}
+
+/* phone numbers tab formatting */
+.callflows-port #user-form #phone_numbers .item-row>* {
+    display: inline-block;
+    padding: 10px;
+    height: 32px;
+    line-height: 32px;
+}
+
+/* phone numbers tab formatting */
+.callflows-port #user-form #phone_numbers .item-row button {
+    margin-right: 25px;
+	text-align: center;
+	line-height: 10px;
+}
+
+/* phone numbers tab formatting */
+.callflows-port #user-form #phone_numbers .number-addition {
+	padding-top: 20px;
+	display: flex;
+    justify-content: flex-end;
+}

--- a/submodules/user/views/addPhoneNumber.html
+++ b/submodules/user/views/addPhoneNumber.html
@@ -1,0 +1,49 @@
+<div class="dialog_popup_new add_number_popup">
+	<form class="form-inline">
+		<div class="popup_field">
+			<input type="radio" id="number_type_1" name="number_type" value="your_numbers" checked="checked" style="display: none;"></input>
+			<label for="number_type_1">{{ i18n.oldCallflows.available_numbers }}</label>
+
+			<div class="list_numbers_content">
+				<select id="list_numbers">
+					{{#each phoneNumbers}}
+						<option value="{{ this.phoneNumber }}">{{ formatPhoneNumber this.phoneNumber }}</option>
+					{{/each}}
+				</select>
+
+				<ul class="nav pull-right number-selection-sidelink">
+					{{#unless hideBuyNumbers}}
+					<li class="dropdown">
+						<a href="#" class="dropdown-toggle buy-dropdown monster-link" data-toggle="dropdown" data-target="#">
+							<i class="fa fa-shopping-cart monster-green fa-lg"></i>
+							{{ i18n.callflows.buyNumbers }}
+						</a>
+						<ul class="dropdown-menu" role="menu">
+							<li><a class="buy-link" data-type="regular" href="#">{{ i18n.callflows.buyLocal }}</a></li>
+							<li><a class="buy-link" data-type="tollfree" href="#">{{ i18n.callflows.buyTollfree }}</a></li>
+							<!-- <li><a class="buy-link" data-type="vanity" href="#">{{ i18n.callflows.buyVanity }}</a></li> -->
+						</ul>
+					</li>
+					{{/unless}}
+				</ul>
+				
+			</div>
+		</div>
+
+		<!--
+		<div class="popup_field">
+			<input type="radio" id="number_type_2" name="number_type" value="extension"></input>
+			<label for="number_type_2">{{ i18n.oldCallflows.extension }}</label>
+
+			<div class="extensions_content">
+				<input id="add_number_text" placeholder="2001" type="text" name="number"/>
+				<a href="javascript:void(0);" class="number-selection-sidelink search-extension-link">{{ i18n.callflows.findExtension }}</a>
+			</div>
+		</div>
+		-->
+		
+		<div class="buttons">
+			<button class="monster-button monster-button-primary add_number">{{ i18n.oldCallflows.add }}</button>
+		</div>
+	</form>
+</div>

--- a/submodules/user/views/edit.html
+++ b/submodules/user/views/edit.html
@@ -17,6 +17,7 @@
 	<ul class="tabs" data-tabs="tabs">
 		<li class="active"><a href="#basic">{{ i18n.callflows.user.basic }}</a></li>
 		<li><a href="#caller_id">{{ i18n.callflows.user.caller_id }}</a></li>
+		<li><a href="#phone_numbers">{{ i18n.callflows.user.phone_numbers }}</a></li>
 		<li><a href="#voicemail">{{ i18n.callflows.user.voicemail }}</a></li>
 		<li><a href="#options">{{ i18n.callflows.user.options }}</a></li>
 		<li><a href="#call_forward">{{ i18n.callflows.user.call_forward }}</a></li>
@@ -375,6 +376,20 @@
 					</div>
 				{{/unless}}
 			{{/if}}
+			</div>
+
+			<div id="phone_numbers">
+				<h3>{{ i18n.callflows.user.phone_numbers_options }}</h3>
+			
+				<div id="phone_numbers_container">
+					<!-- placeholder for numberRow.html -->
+					<div class="numberRows">
+					</div>
+				</div>
+			
+				<div class="number-addition">
+					<button class="monster-button add-phone-number">{{ i18n.callflows.user.phone_numbers_add }}</button>
+				</div>
 			</div>
 
 			<div id="voicemail">

--- a/submodules/user/views/numberRow.html
+++ b/submodules/user/views/numberRow.html
@@ -1,0 +1,24 @@
+<div class="row">
+    {{#if phone_numbers}}
+    <div id="phone_numbers_container">
+        {{#each phone_numbers}}
+        <div class="item-row">
+            
+            <div class="number-container">
+                <button type="button" class="monster-button monster-button-danger unassign-phone-number">{{ @root.i18n.unassign }}</button>
+                
+                <span class="number">
+                    <label class="phone-number-label">{{ formatPhoneNumber this }}</label>
+                    <input id="phone_numbers" name="phone_numbers[]" type="hidden" value="{{ this }}" />
+                </span>
+                                
+            </div>
+
+        </div>
+        <hr>
+        {{/each}}
+    </div>
+    {{else}}
+	    <div class="phone-numbers-none">{{ i18n.callflows.user.phone_numbers_none }}</div>
+    {{/if}}
+</div>


### PR DESCRIPTION
Ability to add or remove DDI numbers to a user. 
Changes update the users callflow, removing the need to do this via SmartPBX or building another callflow to route to the user. 

![image](https://github.com/Dimensions-Technologies/monster-ui-callflows/assets/151521236/7584b672-eb4c-43f1-ad01-9dada9a1e893)
